### PR TITLE
Added a fix to allow ids of newly created assets to be returned

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -232,7 +232,9 @@
      }
      */
     ArtifactManager.prototype.add = function (options) {
-        this.manager.addGenericArtifact(createArtifact(this.manager, options));
+        var asset=createArtifact(this.manager, options);
+        this.manager.addGenericArtifact(asset);
+        return asset.getId();
     };
 
     ArtifactManager.prototype.update = function (options) {


### PR DESCRIPTION
This commit is required for ES 1.2.0-M2
