### PR TITLE
Adding callback_url support to OAuth

### DIFF
--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
@@ -11,6 +11,7 @@ public class GenericOAuth20Api extends DefaultApi20 {
     private String AUTHORIZE_URL;
     private String ACCESS_TOKEN_EP;
     private String CALLBACK_URL;
+    private String SCOPE;
 
 	public void setAuthorizeUrl(String authorizeUrl) {
         this.AUTHORIZE_URL = authorizeUrl;
@@ -33,17 +34,25 @@ public class GenericOAuth20Api extends DefaultApi20 {
 		CALLBACK_URL = cALLBACK_URL;
 	}
 
+    public String getScope() {
+        return SCOPE;
+    }
+
+    public void setScope(String scope) {
+        this.SCOPE = scope;
+    }
+
     @Override
     public String getAuthorizationUrl(OAuthConfig config) {
         Preconditions.checkValidUrl(getCallBackUrl(), "Must provide a valid url as callback.");
 
         // Append scope if present
-        if (config.hasScope()) {
+        if (getScope() != null && !getScope().trim().equals("")) {
             return AUTHORIZE_URL
                     + "?client_id=" + config.getApiKey()
                     + "&response_type=code"
                     + "&redirect_uri=" + OAuthEncoder.encode(getCallBackUrl())
-                    + "&scope=" + OAuthEncoder.encode(config.getScope());
+                    + "&scope=" + OAuthEncoder.encode(this.getScope());
         } else {
             return AUTHORIZE_URL
                     + "?client_id=" + config.getApiKey()

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -99,6 +99,7 @@ public class OAuthHostObject extends ScriptableObject {
                     GenericOAuth20Api oauth20Api = new GenericOAuth20Api();
                     oauth20Api.setAccessTokenEP(providerConfig.getAccess_token_url());
                     oauth20Api.setAuthorizeUrl(providerConfig.getAuthorization_url());
+                    oauth20Api.setCallBackUrl(providerConfig.getCallback_url());
                     oauthho.oauthService = new ServiceBuilder()
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -100,6 +100,7 @@ public class OAuthHostObject extends ScriptableObject {
                     oauth20Api.setAccessTokenEP(providerConfig.getAccess_token_url());
                     oauth20Api.setAuthorizeUrl(providerConfig.getAuthorization_url());
                     oauth20Api.setCallBackUrl(providerConfig.getCallback_url());
+                    oauth20Api.setScope(providerConfig.getScope());
                     oauthho.oauthService = new ServiceBuilder()
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -25,6 +25,7 @@ public class OAuthHostObject extends ScriptableObject {
     private Verifier verifier;
     private Response response;
     private OAuthVersion oAuthVersion;
+    private String callback;
     
     enum OAuthVersion {
     	OAUTH1, OAUTH2
@@ -68,6 +69,7 @@ public class OAuthHostObject extends ScriptableObject {
 
                 oauthho.apiKey = providerConfig.getApi_key();
                 oauthho.apiSecret = providerConfig.getApi_secret();
+                oauthho.callback = (providerConfig.getCallback_url() != null) ? providerConfig.getCallback_url() : OAuthConstants.OUT_OF_BAND;
 
                 if (providerConfig.getOAuth_version() == 1.0) {
                 	
@@ -84,6 +86,7 @@ public class OAuthHostObject extends ScriptableObject {
                             .provider(oauth10aApi)
                             .apiKey(oauthho.apiKey)
                             .apiSecret(oauthho.apiSecret)
+                            .callback(oauthho.callback)
                             .build();
 
                 } else if (providerConfig.getOAuth_version() == 2.0) {
@@ -100,6 +103,7 @@ public class OAuthHostObject extends ScriptableObject {
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)
                             .apiSecret(oauthho.apiSecret)
+                            .callback(oauthho.callback)
                             .build();
                 }
 

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
@@ -9,6 +9,7 @@ public class ProviderConfig {
     private String callback_url;
 	private String api_key;
     private String api_secret;
+    private String scope;
 
     public ProviderConfig() {
     }
@@ -67,5 +68,13 @@ public class ProviderConfig {
 
     public void setApi_secret(String api_secret) {
         this.api_secret = api_secret;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 }


### PR DESCRIPTION
Hi,

Currently Jaggery OAuth module doesn't support OAuth callback urls. After this Jaggery developer can send callback url in provider as follows:

var provider = {
    "oauth_version"     : "1",
    "authorization_url" : "https://api.twitter.com/oauth/authorize",
    "access_token_url"  : "https://api.twitter.com/oauth/access_token",
    "request_token_url" : "https://api.twitter.com/oauth/request_token",
    "api_key"           : "API_KEY",
    "api_secret"        : "API_SECRET",
    "callback_url"  : "http://127.0.0.1:9763/test/"
};

Thanks!
