### PR TITLE
OAuth2 fix

### DIFF
--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
@@ -6,12 +6,15 @@ import org.scribe.utils.Preconditions;
 
 import org.scribe.utils.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 
 public class GenericOAuth20Api extends DefaultApi20 {
     private String AUTHORIZE_URL;
     private String ACCESS_TOKEN_EP;
     private String CALLBACK_URL;
-    private String SCOPE;
+    private HashMap<String, String> AUTHORIZE_PARAMS;
 
 	public void setAuthorizeUrl(String authorizeUrl) {
         this.AUTHORIZE_URL = authorizeUrl;
@@ -34,30 +37,33 @@ public class GenericOAuth20Api extends DefaultApi20 {
 		CALLBACK_URL = cALLBACK_URL;
 	}
 
-    public String getScope() {
-        return SCOPE;
+    public HashMap<String, String> getAuthorizeParams() {
+        return AUTHORIZE_PARAMS;
     }
 
-    public void setScope(String scope) {
-        this.SCOPE = scope;
+    public void setAuthorizeParams(HashMap authirizeParams) {
+        this.AUTHORIZE_PARAMS = authirizeParams;
     }
 
     @Override
     public String getAuthorizationUrl(OAuthConfig config) {
         Preconditions.checkValidUrl(getCallBackUrl(), "Must provide a valid url as callback.");
 
-        // Append scope if present
-        if (getScope() != null && !getScope().trim().equals("")) {
-            return AUTHORIZE_URL
-                    + "?client_id=" + config.getApiKey()
-                    + "&response_type=code"
-                    + "&redirect_uri=" + OAuthEncoder.encode(getCallBackUrl())
-                    + "&scope=" + OAuthEncoder.encode(this.getScope());
-        } else {
-            return AUTHORIZE_URL
+        String authorizeUrl = AUTHORIZE_URL
                     + "?client_id=" + config.getApiKey()
                     + "&response_type=code"
                     + "&redirect_uri=" + OAuthEncoder.encode(getCallBackUrl());
+
+        // Append additional authorizing_params if present
+        if (getAuthorizeParams() != null) {
+            for (Map.Entry<String, String> entry : getAuthorizeParams().entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+
+                authorizeUrl += "&" + key + "=" + OAuthEncoder.encode(value);
+            }
         }
+
+        return authorizeUrl;
     }
 }

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/GenericOAuth20Api.java
@@ -11,6 +11,7 @@ public class GenericOAuth20Api extends DefaultApi20 {
     private String AUTHORIZE_URL;
     private String ACCESS_TOKEN_EP;
     private String CALLBACK_URL;
+    private String SCOPE;
 
 	public void setAuthorizeUrl(String authorizeUrl) {
         this.AUTHORIZE_URL = authorizeUrl;
@@ -33,17 +34,25 @@ public class GenericOAuth20Api extends DefaultApi20 {
 		CALLBACK_URL = cALLBACK_URL;
 	}
 
+    public String getScope() {
+        return SCOPE;
+    }
+
+    public void setScope(String scope) {
+        this.SCOPE = scope;
+    }
+
     @Override
     public String getAuthorizationUrl(OAuthConfig config) {
         Preconditions.checkValidUrl(getCallBackUrl(), "Must provide a valid url as callback.");
 
         // Append scope if present
-        if (config.hasScope()) {
+        if (getScope() != null && !getScope().trim().equals("")) {
             return AUTHORIZE_URL
                     + "?client_id=" + config.getApiKey()
                     + "&response_type=code"
                     + "&redirect_uri=" + OAuthEncoder.encode(getCallBackUrl())
-                    + "&scope=" + OAuthEncoder.encode(config.getScope());
+                    + "&scope=" + OAuthEncoder.encode(this.getScope());
         } else {
             return AUTHORIZE_URL
                     + "?client_id=" + config.getApiKey()

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -99,6 +99,7 @@ public class OAuthHostObject extends ScriptableObject {
                     GenericOAuth20Api oauth20Api = new GenericOAuth20Api();
                     oauth20Api.setAccessTokenEP(providerConfig.getAccess_token_url());
                     oauth20Api.setAuthorizeUrl(providerConfig.getAuthorization_url());
+                    oauth20Api.setCallBackUrl(providerConfig.getCallback_url());
                     oauthho.oauthService = new ServiceBuilder()
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -100,6 +100,7 @@ public class OAuthHostObject extends ScriptableObject {
                     oauth20Api.setAccessTokenEP(providerConfig.getAccess_token_url());
                     oauth20Api.setAuthorizeUrl(providerConfig.getAuthorization_url());
                     oauth20Api.setCallBackUrl(providerConfig.getCallback_url());
+                    oauth20Api.setScope(providerConfig.getScope());
                     oauthho.oauthService = new ServiceBuilder()
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -25,6 +25,7 @@ public class OAuthHostObject extends ScriptableObject {
     private Verifier verifier;
     private Response response;
     private OAuthVersion oAuthVersion;
+    private String callback;
     
     enum OAuthVersion {
     	OAUTH1, OAUTH2
@@ -68,6 +69,7 @@ public class OAuthHostObject extends ScriptableObject {
 
                 oauthho.apiKey = providerConfig.getApi_key();
                 oauthho.apiSecret = providerConfig.getApi_secret();
+                oauthho.callback = (providerConfig.getCallback_url() != null) ? providerConfig.getCallback_url() : OAuthConstants.OUT_OF_BAND;
 
                 if (providerConfig.getOAuth_version() == 1.0) {
                 	
@@ -84,6 +86,7 @@ public class OAuthHostObject extends ScriptableObject {
                             .provider(oauth10aApi)
                             .apiKey(oauthho.apiKey)
                             .apiSecret(oauthho.apiSecret)
+                            .callback(oauthho.callback)
                             .build();
 
                 } else if (providerConfig.getOAuth_version() == 2.0) {
@@ -100,6 +103,7 @@ public class OAuthHostObject extends ScriptableObject {
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)
                             .apiSecret(oauthho.apiSecret)
+                            .callback(oauthho.callback)
                             .build();
                 }
 

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/OAuthHostObject.java
@@ -100,7 +100,7 @@ public class OAuthHostObject extends ScriptableObject {
                     oauth20Api.setAccessTokenEP(providerConfig.getAccess_token_url());
                     oauth20Api.setAuthorizeUrl(providerConfig.getAuthorization_url());
                     oauth20Api.setCallBackUrl(providerConfig.getCallback_url());
-                    oauth20Api.setScope(providerConfig.getScope());
+                    oauth20Api.setAuthorizeParams(providerConfig.getAuthorize_params());
                     oauthho.oauthService = new ServiceBuilder()
                             .provider(oauth20Api)
                             .apiKey(oauthho.apiKey)

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
@@ -1,5 +1,7 @@
 package org.jaggeryjs.modules.oauth;
 
+import java.util.HashMap;
+
 public class ProviderConfig {
 
     private Float oauth_version;
@@ -9,7 +11,7 @@ public class ProviderConfig {
     private String callback_url;
 	private String api_key;
     private String api_secret;
-    private String scope;
+    private HashMap<String, String> authorize_params;
 
     public ProviderConfig() {
     }
@@ -70,11 +72,11 @@ public class ProviderConfig {
         this.api_secret = api_secret;
     }
 
-    public String getScope() {
-        return scope;
+    public HashMap getAuthorize_params() {
+        return authorize_params;
     }
 
-    public void setScope(String scope) {
-        this.scope = scope;
+    public void setAuthorize_params(HashMap authorize_params) {
+        this.authorize_params = authorize_params;
     }
 }

--- a/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
+++ b/oauth/resources/org.jaggeryjs.modules.oauth/src/main/java/org/jaggeryjs/modules/oauth/ProviderConfig.java
@@ -9,6 +9,7 @@ public class ProviderConfig {
     private String callback_url;
 	private String api_key;
     private String api_secret;
+    private String scope;
 
     public ProviderConfig() {
     }
@@ -67,5 +68,13 @@ public class ProviderConfig {
 
     public void setApi_secret(String api_secret) {
         this.api_secret = api_secret;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 }


### PR DESCRIPTION
Hi,
In addition to the changes in PR https://github.com/wso2/jaggery-extensions/pull/9, this PR do following changes:

In OAuth2, for authorizing phase, different services require different set of parameters. But current implementation is not capable of handling it. With this PR, you can set all those additional params for authorizing phase as follows:

``` json
{
    "oauth_version"     : "2",
    "authorization_url" : "https://accounts.google.com/o/oauth2/auth",
    "access_token_url"  : "https://accounts.google.com/o/oauth2/token",
    "api_key"           : "API_KEY.googleusercontent.com",
    "api_secret"        : "API_SECRET",
    "callback_url"      : "http://127.0.0.1:9763/wso2",
        "authorize_params": {
                "state": "wso2oauthtrial",
                "scope": "https://www.googleapis.com/auth/drive.readonly ",
                "access_type":"offline",
                "approval_prompt":"force"
                }
}
```

I also put the 'scope' parameter inside 'authorize_params' since it's also not an essential one.
