### PR TITLE
Multiple lifecycle and strict search functionality

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -331,10 +331,16 @@
         var artifact = this.manager.getGenericArtifact(id);
         var lcs = [];
         if(!artifact){
-            log.error('Artifact id '+assetId+' was not located');
+            log.error('Asset with id '+assetId+' was not located thus the available lifecycles could not be returned.'
+                +'Please make sure that a valid id is provided and the asset manager is of the same type as the asset.');
             return lcs;
         }
-        return artifact.getLifecycleNames();
+        var availableLifecycles = artifact.getLifecycleNames(); 
+        //The returned object is a Java String array so must be converted
+        for(var index = 0 ; index< availableLifecycles.length; index++){
+            lcs.push(String(availableLifecycles[index]));
+        }
+        return lcs;
     };
     /*
      The function checks whether a given check list item at the provided index is checked for the current state

--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -322,6 +322,20 @@
         return checkListItemArray;
     };
 
+    /**
+     * Returns a list of all lifecycles that have been attached to the provided asset.
+     * @param  {Number} assetId UUID
+     * @return {Array}         An array containing all attached lifecycles
+     */
+    ArtifactManager.prototype.listAllAttachedLifecycles = function(id){
+        var artifact = this.manager.getGenericArtifact(id);
+        var lcs = [];
+        if(!artifact){
+            log.error('Artifact id '+assetId+' was not located');
+            return lcs;
+        }
+        return artifact.getLifecycleNames();
+    };
     /*
      The function checks whether a given check list item at the provided index is checked for the current state
      @index: The index of the check list item.This must be a value between 0 and the maximum check list item

--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -99,6 +99,23 @@
         return artifact;
     };
 
+    /**
+     * Determines if there is a lifecycle argument provided
+     * when the function is invoked
+     * @param  {Array} args  The function arguments array
+     * @param  {Object} artifact  The artifact instance
+     * @param  {Number} index The index at which the lifecycle name must be checked
+     * @return {String|NULL}       If the lifecycle name is provided it is returned else NULL
+     */
+    var resolveLCName = function(args,artifact,index){
+        if((args.length -1) < index){
+            var lc =getLifecycleName(artifact);
+            log.info('lc retrieved from artifact :: '+lc);
+            return lc;
+        }
+        log.info('lc retrieved from explicit lifecycle parameter ::'+args[index]);
+        return args[index];
+    };
     var ArtifactManager = function (registry, type) {
         this.registry = registry;
         this.manager = new GenericArtifactManager(registry.registry.getChrootedRegistry("/_system/governance"), type);
@@ -268,7 +285,7 @@
         if (!artifact) {
             throw new Error('Specified artifact cannot be found : ' + JSON.stringify(options));
         }
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,1);//getLifecycleName(artifact);
         artifact.detachLifecycle(lifecycleName);
     };
 
@@ -277,27 +294,29 @@
      @options: An artifact image (Not a real artifact)
      */
     ArtifactManager.prototype.promoteLifecycleState = function (state, options) {
+        log.info('### promoteLifecycleState ###');
         var checkListItems,
             artifact = getArtifactFromImage(this.manager, options);
         if (!artifact) {
             throw new Error('Specified artifact cannot be found : ' + JSON.stringify(options));
         }
         //checkListItems = artifact.getAllCheckListItemNames();
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         artifact.invokeAction(state,lifecycleName);
     };
-
     /*
      Gets the current lifecycle state
      @options: An artifact object
      @returns: The life cycle state
      */
     ArtifactManager.prototype.getLifecycleState = function (options) {
+        log.info('### getLifecycleState ###');
         var artifact = getArtifactFromImage(this.manager, options);
+        var lifecycleName = resolveLCName(arguments,artifact,1);
         if (!artifact) {
             throw new Error('Specified artifact cannot be found : ' + JSON.stringify(options));
         }
-        return artifact.getLifecycleState();
+        return artifact.getLifecycleState(lifecycleName);
     };
 
     /*
@@ -306,8 +325,9 @@
      @returns: A String array containing the check list items.(Can be empty if no check list items are present)
      */
     ArtifactManager.prototype.getCheckListItemNames = function (options) {
+        log.info('### getCheckListItemNames ###');
         var artifact = getArtifactFromImage(this.manager, options);
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,1);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName) || [];
 
         var checkListItemArray = [];
@@ -350,9 +370,9 @@
      @throws Exception: If the index is not within 0 and the max check list item or if there is an issue ticking the item
      */
     ArtifactManager.prototype.isItemChecked = function (index, options) {
-
+        log.info('### isItemChecked ###');
         var artifact = getArtifactFromImage(this.manager, options);
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames();
 
         var checkListLength = checkListItems.length;
@@ -373,9 +393,9 @@
      @throws Exception: If the index is not within 0 and max check list item or if there is an issue ticking the item.
      */
     ArtifactManager.prototype.checkItem = function (index, options) {
-
+        log.info('### checkItem ###');
         var artifact = getArtifactFromImage(this.manager, options);
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName);
 
         var checkListLength = checkListItems.length;
@@ -394,9 +414,9 @@
      @throws Exception: If the index is not within 0 and max check list item or if there is an issue ticking the item
      */
     ArtifactManager.prototype.uncheckItem = function (index, options) {
-
+        log.info('### uncheckItem ###');
         var artifact = getArtifactFromImage(this.manager, options);
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName);
 
         var checkListLength = checkListItems.length;
@@ -413,11 +433,12 @@
      @returns: The list of available actions for the current state,else false
      */
     ArtifactManager.prototype.availableActions = function (options) {
+        log.info('### availableActions ###');
         var artifact = getArtifactFromImage(this.manager, options);
         if (!artifact) {
             throw new Error('Specified artifact cannot be found : ' + JSON.stringify(options));
         }
-	    var lifecycleName = getLifecycleName(artifact);
+	    var lifecycleName = resolveLCName(arguments,artifact,1);//getLifecycleName(artifact);
         return artifact.getAllLifecycleActions(lifecycleName) || [];
     };
 

--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -397,7 +397,7 @@
 
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = getLifecycleName(artifact);
-        var checkListItems = artifact.getAllCheckListItemNames();
+        var checkListItems = artifact.getAllCheckListItemNames(lifecycleName);
 
         var checkListLength = checkListItems.length;
 

--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -110,10 +110,8 @@
     var resolveLCName = function(args,artifact,index){
         if((args.length -1) < index){
             var lc =getLifecycleName(artifact);
-            log.info('lc retrieved from artifact :: '+lc);
             return lc;
         }
-        log.info('lc retrieved from explicit lifecycle parameter ::'+args[index]);
         return args[index];
     };
     var ArtifactManager = function (registry, type) {
@@ -294,7 +292,6 @@
      @options: An artifact image (Not a real artifact)
      */
     ArtifactManager.prototype.promoteLifecycleState = function (state, options) {
-        log.info('### promoteLifecycleState ###');
         var checkListItems,
             artifact = getArtifactFromImage(this.manager, options);
         if (!artifact) {
@@ -310,7 +307,6 @@
      @returns: The life cycle state
      */
     ArtifactManager.prototype.getLifecycleState = function (options) {
-        log.info('### getLifecycleState ###');
         var artifact = getArtifactFromImage(this.manager, options);
         var lifecycleName = resolveLCName(arguments,artifact,1);
         if (!artifact) {
@@ -325,13 +321,8 @@
      @returns: A String array containing the check list items.(Can be empty if no check list items are present)
      */
     ArtifactManager.prototype.getCheckListItemNames = function (options) {
-        log.info('### getCheckListItemNames ###');
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = resolveLCName(arguments,artifact,1);//getLifecycleName(artifact);
-        for(var i in arguments){
-            log.info(arguments[i]);
-        }
-        log.info('### done ###');
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName) || [];
 
         var checkListItemArray = [];
@@ -374,7 +365,6 @@
      @throws Exception: If the index is not within 0 and the max check list item or if there is an issue ticking the item
      */
     ArtifactManager.prototype.isItemChecked = function (index, options) {
-        log.info('### isItemChecked ###');
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames();
@@ -397,7 +387,6 @@
      @throws Exception: If the index is not within 0 and max check list item or if there is an issue ticking the item.
      */
     ArtifactManager.prototype.checkItem = function (index, options) {
-        log.info('### checkItem ###');
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName);
@@ -418,7 +407,6 @@
      @throws Exception: If the index is not within 0 and max check list item or if there is an issue ticking the item
      */
     ArtifactManager.prototype.uncheckItem = function (index, options) {
-        log.info('### uncheckItem ###');
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName);
@@ -437,7 +425,6 @@
      @returns: The list of available actions for the current state,else false
      */
     ArtifactManager.prototype.availableActions = function (options) {
-        log.info('### availableActions ###');
         var artifact = getArtifactFromImage(this.manager, options);
         if (!artifact) {
             throw new Error('Specified artifact cannot be found : ' + JSON.stringify(options));

--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -328,6 +328,10 @@
         log.info('### getCheckListItemNames ###');
         var artifact = getArtifactFromImage(this.manager, options);
 	    var lifecycleName = resolveLCName(arguments,artifact,1);//getLifecycleName(artifact);
+        for(var i in arguments){
+            log.info(arguments[i]);
+        }
+        log.info('### done ###');
         var checkListItems = artifact.getAllCheckListItemNames(lifecycleName) || [];
 
         var checkListItemArray = [];


### PR DESCRIPTION
This PR contains changes which are required for the following functionality:
1. Support for multiple Lifecycles
2. Support for strict searches 

## Support for multiple Lifecycles
* Changes to all Lifecycle methods that allow the lifecycle name to be specified when an asset has multiple Lifecycles attached
* If a Lifecycle name is not provided then the methods will use the default lifecycle of the asset to perform the operation

## Support for strict search
* The search method performs a wildcard addition to all query parameters
* The strictSearch method which has been added in this PR will use the literal value of query parameters without prefixing or post fixing wildcard tokens
