### PR TITLE
fix on Jira STORE-720 - Lifecycle History

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -24,7 +24,7 @@
     var HISTORY_PATH_SEPERATOR = '_';
     var ASSET_PATH_SEPERATOR = '/';
     var lcHistoryRegExpression = new RegExp(ASSET_PATH_SEPERATOR, 'g');
-    var HISTORY_PATH = '/_system/governance/_system/governance/repository/components/org.wso2.carbon.governance/lifecycles/history/';
+    var HISTORY_PATH = '/_system/governance/repository/components/org.wso2.carbon.governance/lifecycles/history/';
 
 
     var buildArtifact = function (manager, artifact) {

--- a/carbon/module/scripts/registry/registry-osgi.js
+++ b/carbon/module/scripts/registry/registry-osgi.js
@@ -405,6 +405,9 @@ var registry = registry || {};
         this.registry.rateResource(path, rating);
     };
 
+    Registry.prototype.invokeAspect = function (path,aspectName,action,parameters) { 
+	this.registry.invokeAspect(path,aspectName,action,parameters);
+    }
     Registry.prototype.unrate = function (path) {
         this.registry.rateResource(path, 0);
     };


### PR DESCRIPTION
If the Promote/Demote actions for an asset done via Admin Console, History Life Cycle records are not displayed in the Publisher