### PR TITLE
Fix on Jira STORE-720

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -24,7 +24,7 @@
     var HISTORY_PATH_SEPERATOR = '_';
     var ASSET_PATH_SEPERATOR = '/';
     var lcHistoryRegExpression = new RegExp(ASSET_PATH_SEPERATOR, 'g');
-    var HISTORY_PATH = '/_system/governance/_system/governance/repository/components/org.wso2.carbon.governance/lifecycles/history/';
+    var HISTORY_PATH = '/_system/governance/repository/components/org.wso2.carbon.governance/lifecycles/history/';
 
 
     var buildArtifact = function (manager, artifact) {
@@ -347,7 +347,9 @@
         }
         //checkListItems = artifact.getAllCheckListItemNames();
 	    var lifecycleName = resolveLCName(arguments,artifact,2);//getLifecycleName(artifact);
-        artifact.invokeAction(state,lifecycleName);
+        //artifact.invokeAction(state,lifecycleName);
+        this.registry.invokeAspect(options.path,lifecycleName,state,{});
+
     };
     /*
      Gets the current lifecycle state

--- a/carbon/module/scripts/registry/registry-osgi.js
+++ b/carbon/module/scripts/registry/registry-osgi.js
@@ -265,6 +265,10 @@ var registry = registry || {};
         return this.registry.resourceExists(path);
     };
 
+    Registry.prototype.invokeAspect = function (path,aspectName,action,parameters) {
+        this.registry.invokeAspect(path,aspectName,action,parameters);
+    };
+
     Registry.prototype.content = function (path, paging) {
         if (!this.exists(path)) {
             return null;


### PR DESCRIPTION
If the Promote/Demote actions for an asset done via Admin Console, History Life Cycle records are not displayed in the Publisher.