### PR TITLE
Fix for null values corrupting asset resource definition

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -47,7 +47,10 @@
 
                     //Check if there is only one element
                     if (data.length == 1) {
-                        attributes[name] = String(artifact.getAttribute(name));
+                        //Make sure the attribute has a value
+                        if(artifact.getAttribute(name)!=null){
+                            attributes[name] = String(artifact.getAttribute(name));
+                        }
                     }
                     else {
                         attributes[name] = data;


### PR DESCRIPTION
**IMPORTANT**: Do not merge
Check for null values before adding attributes