### PR TITLE
Fix for STORE-1248

### DIFF
--- a/carbon/module/scripts/registry/artifacts.js
+++ b/carbon/module/scripts/registry/artifacts.js
@@ -245,7 +245,10 @@
     }
 
     ArtifactManager.prototype.get = function (id) {
-        return buildArtifact(this, this.manager.getGenericArtifact(id))
+        var artifact = this.manager.getGenericArtifact(id);
+        //An asset may not be returned in some scenarios (e.g. a user does not have access
+        //to the asset)
+        return artifact ? buildArtifact(this,artifact) : null;
     };
 
     ArtifactManager.prototype.count = function () {


### PR DESCRIPTION
This PR checks if an asset is returned by the Governance API before building JSON representation.

Addresses the following issue: [STORE-1248](https://wso2.org/jira/browse/STORE-1248)