### PR TITLE
Fix for STORE-1307: Iterate over array of codes files and evaluate them  

### DIFF
--- a/caramel/module/scripts/caramel.handlebars.js
+++ b/caramel/module/scripts/caramel.handlebars.js
@@ -606,7 +606,9 @@ engine('handlebars', (function () {
                                     o = helper.resources(page, meta);
                                     blockData.resources.js = resolve('js', o.js);
                                     blockData.resources.css = resolve('css', o.css);
-                                    blockData.resources.code = o.code ? evalCode(o.code, meta.data, theme) : null;
+                                    blockData.resources.code = o.code ? o.code.reduce(function(pre,cur){
+                                        return pre + evalCode(cur, meta.data, theme);
+                                    },"") : null;
                                 }
                             }
                         }


### PR DESCRIPTION
In this PR:
*  add new array reduce operation to , reduce all the inline code segments into single code segment HTML string 

Addresses the following issue: [STORE-1307](https://wso2.org/jira/browse/STORE-1307)