### PR TITLE
Fix to validateSignature method

### DIFF
--- a/sso/resources/org.jaggeryjs.modules.sso/src/main/java/org/jaggeryjs/modules/sso/common/util/Util.java
+++ b/sso/resources/org.jaggeryjs.modules.sso/src/main/java/org/jaggeryjs/modules/sso/common/util/Util.java
@@ -26,6 +26,7 @@ import org.opensaml.Configuration;
 import org.opensaml.common.impl.SecureRandomIdentifierGenerator;
 import org.opensaml.DefaultBootstrap;
 import org.opensaml.saml2.core.Response;
+import org.opensaml.saml2.core.impl.StatusResponseTypeImpl;
 import org.opensaml.xml.ConfigurationException;
 import org.opensaml.xml.XMLObject;
 import org.opensaml.xml.XMLObjectBuilder;
@@ -256,7 +257,7 @@ public class Util {
      * @param resp SAML Response
      * @return true, if signature is valid.
      */
-    public static boolean validateSignature(Response resp, String keyStoreName,
+    public static boolean validateSignature(StatusResponseTypeImpl resp, String keyStoreName,
                                             String keyStorePassword, String alias, int tenantId,
                                             String tenantDomain) {
         boolean isSigValid = false;


### PR DESCRIPTION
This PR contains the following fix:
- The validateSignature method can bow validate SAML login and logout responses.
