### PR TITLE
Removed dependency on commons sso

### DIFF
--- a/sso/feature/pom.xml
+++ b/sso/feature/pom.xml
@@ -96,10 +96,6 @@
                             <bundles>
                                 <bundleDef>org.jaggeryjs.modules.sso:org.jaggeryjs.modules.sso</bundleDef>
                             </bundles>
-                            <importBundles>
-                                <importBundleDef>org.wso2.carbon.commons:org.wso2.carbon.hostobjects.sso
-                                </importBundleDef>
-                            </importBundles>
                         </configuration>
                     </execution>
                 </executions>

--- a/sso/module/module.xml
+++ b/sso/module/module.xml
@@ -3,8 +3,4 @@
         <name>client</name>
         <path>scripts/sso.client.js</path>
     </script>
-    <hostObject>
-        <className>org.wso2.carbon.hostobjects.sso.SAMLSSORelyingPartyObject</className>
-        <name>SSORelyingParty</name>
-    </hostObject>
 </module>


### PR DESCRIPTION
This PR removes a dependency to the carbon commons hostobject which is no longer used in the sso module.