### PR TITLE
adding shibboleth repo temporarily until a proper redirection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,15 @@
 
     <repositories>
         <repository>
+            <id>shibboleth.internet2.edu</id>
+            <name>Internet2</name>
+            <layout>default</layout>
+            <url>https://build.shibboleth.net/nexus/content/groups/public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>wso2-nexus</id>
             <name>WSO2 Internal Repository</name>
             <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>


### PR DESCRIPTION
http://shibboleth.internet2.edu/downloads/maven2/ repo was moved to a different location and this redirects to web page which causes downloading html content assuming its jars by jenkins